### PR TITLE
Fix Landscape Image

### DIFF
--- a/ios/eagleMobile.xcodeproj/project.pbxproj
+++ b/ios/eagleMobile.xcodeproj/project.pbxproj
@@ -1138,7 +1138,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 7Y3834AL35;
+						DevelopmentTeam = KH9MTRSDAZ;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -1914,7 +1914,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = 7Y3834AL35;
+				DEVELOPMENT_TEAM = KH9MTRSDAZ;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
@@ -1949,7 +1949,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7Y3834AL35;
+				DEVELOPMENT_TEAM = KH9MTRSDAZ;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",

--- a/screens/CameraScreen.js
+++ b/screens/CameraScreen.js
@@ -114,7 +114,7 @@ class CameraScreen extends React.Component {
       let { imageUri, imageHeight, imageWidth } = this.state;
       let controlColour = 'white';
 
-      // Determine the colour of the controls. Make then dark if the image is landscape.
+      // Determine the colour of the controls. Make them dark if the image is landscape.
       if (imageWidth > imageHeight) {
         controlColour = 'black';
       }

--- a/screens/CameraScreen.js
+++ b/screens/CameraScreen.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux'
 import {
   ImageBackground,
   StyleSheet,
-  View
+  View,
+  Image
 } from 'react-native';
 
 import { Button, Icon } from 'react-native-elements'
@@ -27,7 +28,8 @@ class CameraScreen extends React.Component {
     this.state = {
       params: props.navigation.state.params,
       imageUri: null,
-      photos: []
+      imageHeight: null,
+      imageWidth: null,
     }
   }
 
@@ -88,7 +90,14 @@ class CameraScreen extends React.Component {
       const options = { quality: 0.5, base64: true };
       const data = await this.camera.takePictureAsync(options);
       this.setState({ imageUri: data.uri });
-      console.log(data.uri);
+
+      // Get the height and width.
+      Image.getSize(data.uri, (width, height) => {
+        this.setState({
+          imageWidth: width,
+          imageHeight: height,
+        });
+      });
     }
   };
 
@@ -102,7 +111,14 @@ class CameraScreen extends React.Component {
       return null;
     } else {
       // Image from camera
-      let { imageUri } = this.state;
+      let { imageUri, imageHeight, imageWidth } = this.state;
+      let controlColour = 'white';
+
+      // Determine the colour of the controls. Make then dark if the image is landscape.
+      if (imageWidth > imageHeight) {
+        controlColour = 'black';
+      }
+
       if (imageUri) {
         // Preview of image if image is new.s
         return (
@@ -110,6 +126,7 @@ class CameraScreen extends React.Component {
             <ImageBackground
               source={{ uri: imageUri }}
               style={{ width: '100%', height: '100%' }}
+              resizeMode='contain'
             >
               <View style={{
                 flex: 1,
@@ -125,7 +142,7 @@ class CameraScreen extends React.Component {
                       <Icon
                         name="backspace"
                         type='material'
-                        color='white'
+                        color={controlColour}
                         size={50}
                       />
                     }
@@ -137,7 +154,7 @@ class CameraScreen extends React.Component {
                       <Icon
                         name="save"
                         type='material'
-                        color='white'
+                        color={controlColour}
                         size={50}
                       />
                     }

--- a/screens/PreviewElementScreen.js
+++ b/screens/PreviewElementScreen.js
@@ -90,10 +90,17 @@ class PreviewElementScreen extends React.Component {
               justifyContent: 'center',
               alignItems: 'center',
             }}>
-            <Image
-              style={{ width: win.width, height: 540 }}
-              source={{ uri: imageUri }}
-            />
+            <ScrollView
+              maximumZoomScale={2.5}
+              minimumZoomScale={1}
+              pinchGestureEnabled={true}
+            >
+              <Image
+                style={{ width: win.width, height: 540 }}
+                source={{ uri: imageUri }}
+                resizeMode='contain'
+              />
+            </ScrollView>
           </View>
           <View style={{ margin: 25 }}>
             <Text>Lat: {lat}</Text>


### PR DESCRIPTION
- Fixes the display of landscape images when viewing in the element viewer screen. Also allows for zooming on the image
- Fixes landscape display of image when previewing an image taken by the camera. Cannot add zooming on this screen without hanging the on-screen control layout.